### PR TITLE
Fixing OCR errors. There should be commas before ending quotes instead of periods.

### DIFF
--- a/src/epub/text/chapter-1.xhtml
+++ b/src/epub/text/chapter-1.xhtml
@@ -74,7 +74,7 @@
 				</p>
 			</blockquote>
 			<p>“And He is here! The Most Excellent Law is here also. My pilgrimage is well begun. And what work! What work!”</p>
-			<p>“Yonder is the Sahib.” said Kim, and dodged sideways among the cases of the arts and manufacturers wing. A white-bearded Englishman was looking at the lama, who gravely turned and saluted him and after some fumbling drew forth a notebook and a scrap of paper.</p>
+			<p>“Yonder is the Sahib,” said Kim, and dodged sideways among the cases of the arts and manufacturers wing. A white-bearded Englishman was looking at the lama, who gravely turned and saluted him and after some fumbling drew forth a notebook and a scrap of paper.</p>
 			<p>“Yes, that is my name,” smiling at the clumsy, childish print.</p>
 			<p>“One of us who had made pilgrimage to the Holy Places⁠—he is now Abbot of the Lung-Cho Monastery⁠—gave it me,” stammered the lama. “He spoke of these.” His lean hand moved tremulously round.</p>
 			<p>“Welcome, then, O lama from Tibet. Here be the images, and I am here”⁠—he glanced at the lama’s face⁠—“to gather knowledge. Come to my office awhile.” The old man was trembling with excitement.</p>
@@ -137,7 +137,7 @@
 			<p>“Rest, thou. <em>I</em> know the people.”</p>
 			<p>He trotted off to the open shop of a <i xml:lang="hi-Latn">kunjri</i>, a low-caste vegetable-seller, which lay opposite the belt-tramway line down the Motee Bazaar. She knew Kim of old.</p>
 			<p>“Oho, hast thou turned yogi with thy begging-bowl?” she cried.</p>
-			<p>“Nay.” said Kim proudly. “There is a new priest in the city⁠—a man such as I have never seen.”</p>
+			<p>“Nay,” said Kim proudly. “There is a new priest in the city⁠—a man such as I have never seen.”</p>
 			<p>“Old priest⁠—young tiger,” said the woman angrily. “I am tired of new priests! They settle on our wares like flies. Is the father of my son a well of charity to give to all who ask?”</p>
 			<p>“No,” said Kim. “Thy man is rather <i xml:lang="sa-Latn">yagi</i><a href="endnotes.xhtml#note-8" id="noteref-8" epub:type="noteref">8</a> than yogi.<a href="endnotes.xhtml#note-9" id="noteref-9" epub:type="noteref">9</a> But this priest is new. The Sahib in the Wonder House has talked to him like a brother. O my mother, fill me this bowl. He waits.”</p>
 			<p>“That bowl indeed! That cow-bellied basket! Thou hast as much grace as the holy bull of Shiv. He has taken the best of a basket of onions already, this morn; and forsooth, I must fill thy bowl. He comes here again.”</p>
@@ -224,7 +224,7 @@
 			<p>But R17’s report was the kernel of the whole affair, and it would be distinctly inconvenient if that failed to come to hand. However, God was great, and Mahbub Ali felt he had done all he could for the time being. Kim was the one soul in the world who had never told him a lie. That would have been a fatal blot on Kim’s character if Mahbub had not known that to others, for his own ends or Mahbub’s business, Kim could lie like an Oriental.</p>
 			<p>Then Mahbub Ali rolled across the serai to the Gate of the Harpies who paint their eyes and trap the stranger, and was at some pains to call on the one girl who, he had reason to believe, was a particular friend of a smooth-faced Kashmiri pundit who had waylaid his simple Balti in the matter of the telegrams. It was an utterly foolish thing to do; because they fell to drinking perfumed brandy against the Law of the Prophet, and Mahbub grew wonderfully drunk, and the gates of his mouth were loosened, and he pursued the Flower of Delight with the feet of intoxication till he fell flat among the cushions, where the Flower of Delight, aided by a smooth-faced Kashmiri pundit, searched him from head to foot most thoroughly.</p>
 			<p>About the same hour Kim heard soft feet in Mahbub’s deserted stall. The horse-trader, curiously enough, had left his door unlocked, and his men were busy celebrating their return to India with a whole sheep of Mahbub’s bounty. A sleek young gentleman from Delhi, armed with a bunch of keys which the Flower had unshackled from the senseless one’s belt, went through every single box, bundle, mat, and saddlebag in Mahbub’s possession even more systematically than the Flower and the pundit were searching the owner.</p>
-			<p>“And I think.” said the Flower scornfully an hour later, one rounded elbow on the snoring carcass, “that he is no more than a pig of an Afghan horse-dealer, with no thought except women and horses. Moreover, he may have sent it away by now⁠—if ever there were such a thing.”</p>
+			<p>“And I think,” said the Flower scornfully an hour later, one rounded elbow on the snoring carcass, “that he is no more than a pig of an Afghan horse-dealer, with no thought except women and horses. Moreover, he may have sent it away by now⁠—if ever there were such a thing.”</p>
 			<p>“Nay⁠—in a matter touching Five Kings it would be next his black heart,” said the pundit. “Was there nothing?”</p>
 			<p>The Delhi man laughed and resettled his turban as he entered. “I searched between the soles of his slippers as the Flower searched his clothes. This is not the man but another. I leave little unseen.”</p>
 			<p>“They did not say he was the very man,” said the pundit thoughtfully. “They said, ‘Look if he be the man, since our counsels are troubled.’ ”</p>

--- a/src/epub/text/chapter-15.xhtml
+++ b/src/epub/text/chapter-15.xhtml
@@ -51,7 +51,7 @@
 			<p>“Perhaps half a <i xml:lang="sa-Latn">kos</i>.” Three quarters of a mile, and it was a weary march.</p>
 			<p>“Half a <i xml:lang="sa-Latn">kos</i>. Ha! I went ten thousand thousand in the spirit. How, we are all lapped and swathed and swaddled in these senseless things.” He looked at his thin blue-veined hand that found the beads so heavy. “<i xml:lang="sa-Latn">Chela</i>, hast thou never a wish to leave me?”</p>
 			<p>Kim thought of the oilskin packet and the books in the food-bag. If someone duly authorized would only take delivery of them the Great Game might play itself for aught he then cared. He was tired and hot in his head, and a cough that came from the stomach worried him.</p>
-			<p>“No.” he said almost sternly. “I am not a dog or a snake to bite when I have learned to love.”</p>
+			<p>“No,” he said almost sternly. “I am not a dog or a snake to bite when I have learned to love.”</p>
 			<p>“Thou art too tender towards me.”</p>
 			<p>“Not that either. I have moved in one matter without consulting thee. I have sent a message to the Kulu woman by that woman who gave us the goat’s milk this morn, saying that thou wast a little feeble and wouldst need a litter. I beat myself in my mind that I did not do it when we entered the Doon. We stay in this place till the litter returns.”</p>
 			<p>“I am content. She is a woman with a heart of gold, as thou sayest, but a talker⁠—something of a talker.”</p>

--- a/src/epub/text/chapter-2.xhtml
+++ b/src/epub/text/chapter-2.xhtml
@@ -133,7 +133,7 @@
 			<p>“Give a woman an old wife’s tale and a weaverbird a leaf and a thread, they will weave wonderful things,” said the Sikh. “All holy men dream dreams, and by following holy men their disciples attain that power.”</p>
 			<p>“A Red Bull on a green field, was it?” the lama repeated. “In a former life it may be thou hast acquired merit, and the Bull will come to reward thee.”</p>
 			<p>“Nay⁠—nay⁠—it was but a tale one told to me⁠—for a jest belike. But I will seek the Bull about Umballa, and thou canst look for thy River and rest from the clatter of the train.”</p>
-			<p>“It may be that the Bull knows⁠—that he is sent to guide us both.” said the lama, hopefully as a child. Then to the company, indicating Kim: “This one was sent to me but yesterday. He is not, I think, of this world.”</p>
+			<p>“It may be that the Bull knows⁠—that he is sent to guide us both,” said the lama, hopefully as a child. Then to the company, indicating Kim: “This one was sent to me but yesterday. He is not, I think, of this world.”</p>
 			<p>“Beggars aplenty have I met, and holy men to boot, but never such a yogi nor such a disciple,” said the woman.</p>
 			<p>Her husband touched his forehead lightly with one finger and smiled. But the next time the lama would eat they took care to give him of their best.</p>
 			<p>And at last⁠—tired, sleepy, and dusty⁠—they reached Umballa City Station.</p>
@@ -200,7 +200,7 @@
 			<p>“Hm! Thus say the stars. Within three days come the two men to make all things ready. After them follows the Bull; but the sign over against him is the sign of War and armed men.”</p>
 			<p>“There was indeed a man of the Ludhiana Sikhs in the carriage from Lahore,” said the cultivator’s wife hopefully.</p>
 			<p>“Tck! Armed men⁠—many hundreds. What concern hast thou with war?” said the priest to Kim. “Thine is a red and an angry sign of War to be loosed very soon.”</p>
-			<p>“None⁠—none.” said the lama earnestly. “We seek only peace and our River.”</p>
+			<p>“None⁠—none,” said the lama earnestly. “We seek only peace and our River.”</p>
 			<p>Kim smiled, remembering what he had overheard in the dressing-room. Decidedly he was a favourite of the stars.</p>
 			<p>The priest brushed his foot over the rude horoscope. “More than this I cannot see. In three days comes the Bull to thee, boy.”</p>
 			<p>“And my River, my River,” pleaded the lama. “I had hoped his Bull would lead us both to the River.”</p>

--- a/src/epub/text/chapter-3.xhtml
+++ b/src/epub/text/chapter-3.xhtml
@@ -31,7 +31,7 @@
 			<p>“And by what sign didst thou know that we would beg from thee, O Mali?” said Kim tartly, using the name that a market-gardener least likes. “All we sought was to look at that river beyond the field there.”</p>
 			<p>“River, forsooth!” the man snorted. “What city do ye hail from not to know a canal-cut? It runs as straight as an arrow, and I pay for the water as though it were molten silver. There is a branch of a river beyond. But if ye need water I can give that⁠—and milk.”</p>
 			<p>“Nay, we will go to the river,” said the lama, striding out.</p>
-			<p>“Milk and a meal.” the man stammered, as he looked at the strange tall figure. “I⁠—I would not draw evil upon myself⁠—or my crops. But beggars are so many in these hard days.”</p>
+			<p>“Milk and a meal,” the man stammered, as he looked at the strange tall figure. “I⁠—I would not draw evil upon myself⁠—or my crops. But beggars are so many in these hard days.”</p>
 			<p>“Take notice.” The lama turned to Kim. “He was led to speak harshly by the Red Mist of anger. That clearing from his eyes, he becomes courteous and of an affable heart. May his fields be blessed! Beware not to judge men too hastily, O farmer.”</p>
 			<p>“I have met holy ones who would have cursed thee from hearthstone to byre,” said Kim to the abashed man. “Is he not wise and holy? I am his disciple.”</p>
 			<p>He cocked his nose in the air loftily and stepped across the narrow field-borders with great dignity.</p>
@@ -59,7 +59,7 @@
 			<p>He was a white-bearded and affable elder, used to entertaining strangers. He dragged out a string bedstead for the lama, set warm cooked food before him, prepared him a pipe, and, the evening ceremonies being finished in the village temple, sent for the village priest.</p>
 			<p>Kim told the older children tales of the size and beauty of Lahore, of railway travel, and suchlike city things, while the men talked, slowly as their cattle chew the cud.</p>
 			<p>“I cannot fathom it,” said the headman at last to the priest. “How readest thou this talk?” The lama, his tale told, was silently telling his beads.</p>
-			<p>“He is a Seeker.” the priest answered. “The land is full of such. Remember him who came only last, month⁠—the fakir with the tortoise?”</p>
+			<p>“He is a Seeker,” the priest answered. “The land is full of such. Remember him who came only last, month⁠—the fakir with the tortoise?”</p>
 			<p>“Ay, but that man had right and reason, for Krishna Himself appeared in a vision promising him Paradise without the burning-pyre if he journeyed to Prayag. This man seeks no God who is within my knowledge.”</p>
 			<p>“Peace, he is old: he comes from far off, and he is mad,” the smooth-shaven priest replied. “Hear me.” He turned to the lama. “Three <i xml:lang="sa-Latn">kos</i><a href="endnotes.xhtml#note-17" id="noteref-17" epub:type="noteref">17</a> to the westward runs the great road to Calcutta.”</p>
 			<p>“But I would go to Benares⁠—to Benares.”</p>
@@ -189,7 +189,7 @@
 			<p>“What is it to fear? Two old men and a boy? How wilt thou ever make a soldier, Princeling?”</p>
 			<p>The lama had waked too, but, taking no direct notice of the child, clicked his rosary.</p>
 			<p>“What is that?” said the child, stopping a yell midway. “I have never seen such things. Give them me.”</p>
-			<p>“Aha.” said the lama, smiling, and trailing a loop of it on the grass:</p>
+			<p>“Aha,” said the lama, smiling, and trailing a loop of it on the grass:</p>
 			<blockquote epub:type="z3998:song">
 				<p>
 					<span>This is a handful of cardamoms,</span>

--- a/src/epub/text/chapter-5.xhtml
+++ b/src/epub/text/chapter-5.xhtml
@@ -59,7 +59,7 @@
 			<p>“But this is not vision,” said the lama. “It is the world’s Illusion, and no more.”</p>
 			<p>“And after them comes the Bull⁠—the Red Bull on the green field. Look! It is he!”</p>
 			<p>He pointed to the flag that was snap snapping in the evening breeze not ten feet away. It was no more than an ordinary camp marking-flag; but the regiment, always punctilious in matters of millinery, had charged it with the regimental device, the Red Bull, which is the crest of the Mavericks⁠—the great Red Bull on a background of Irish green.</p>
-			<p>“I see, and now I remember.” said the lama. “Certainly it is thy Bull. Certainly, also, the two men came to make all ready.”</p>
+			<p>“I see, and now I remember,” said the lama. “Certainly it is thy Bull. Certainly, also, the two men came to make all ready.”</p>
 			<p>“They are soldiers⁠—white soldiers. What said the priest? ‘The sign over against the Bull is the sign of War and armed men.’ Holy One, this thing touches my Search.”</p>
 			<p>“True. It is true.” The lama stared fixedly at the device that flamed like a ruby in the dusk. “The priest at Umballa said that thine was the sign of War.”</p>
 			<p>“What is to do now?”</p>
@@ -128,7 +128,7 @@
 			<p>“I did <em>not</em> thieve,” protested Kim. “You have hit me kicks all over my body. Now give me my charm and I will go away.”</p>
 			<p>“Not quite so fast. We’ll look first,” said Father Victor, leisurely rolling out poor Kimball O’Hara’s <i xml:lang="la">ne varietur</i> parchment, his clearance-certificate, and Kim’s baptismal certificate. On this last O’Hara⁠—with some confused idea that he was doing wonders for his son⁠—had scrawled scores of times: “<em>Look after the boy. Please look after the boy</em>”⁠—signing his name and regimental number in full.</p>
 			<p>“Powers of Darkness below!” said Father Victor, passing all over to <abbr>Mr.</abbr> Bennett. “Do you know what these things are?”</p>
-			<p>“Yes.” said Kim. “They are mine, and I want to go away.”</p>
+			<p>“Yes,” said Kim. “They are mine, and I want to go away.”</p>
 			<p>“I do not quite understand,” said <abbr>Mr.</abbr> Bennett. “He probably brought them on purpose. It may be a begging trick of some kind.”</p>
 			<p>“I never saw a beggar less anxious to stay with his company, then. There’s the makings of a gay mystery here. Ye believe in Providence, Bennett?”</p>
 			<p>“I hope so.”</p>


### PR DESCRIPTION
Verified each case manually against scans at https://archive.org/details/kimkipling01kipluoft and https://archive.org/details/kimrudyard02kipluoft